### PR TITLE
Handle DynamoDB pagination in survey helper

### DIFF
--- a/__tests__/getOtherResponsesFromSurvey.test.js
+++ b/__tests__/getOtherResponsesFromSurvey.test.js
@@ -1,0 +1,41 @@
+const mockSend = jest.fn();
+
+jest.mock('@aws-sdk/lib-dynamodb', () => {
+  const actual = jest.requireActual('@aws-sdk/lib-dynamodb');
+  return {
+    ...actual,
+    DynamoDBDocumentClient: { from: jest.fn(() => ({ send: mockSend })) },
+    QueryCommand: actual.QueryCommand,
+    UpdateCommand: actual.UpdateCommand
+  };
+});
+
+jest.mock('@aws-sdk/client-dynamodb', () => {
+  return { DynamoDBClient: jest.fn() };
+});
+
+const { getOtherResponsesFromSurvey } = require('../helpers/cross-duplicate-utils');
+
+beforeEach(() => {
+  mockSend.mockReset();
+  process.env.IS_OFFLINE = 'false';
+});
+
+test('combines results from multiple pages', async () => {
+  mockSend
+    .mockResolvedValueOnce({
+      Items: [{ participantId: 'p1', responses: { q1: 'Hi' } }],
+      LastEvaluatedKey: { id: '1' }
+    })
+    .mockResolvedValueOnce({
+      Items: [{ participantId: 'p2', responses: { q1: 'Bye' } }]
+    });
+
+  const result = await getOtherResponsesFromSurvey({}, 'survey1', 'other');
+
+  expect(mockSend).toHaveBeenCalledTimes(2);
+  expect(result.q1).toEqual([
+    { finalState: 'hi', participantId: 'p1', responseGroup: 0 },
+    { finalState: 'bye', participantId: 'p2', responseGroup: 0 }
+  ]);
+});

--- a/helpers/cross-duplicate-utils.js
+++ b/helpers/cross-duplicate-utils.js
@@ -62,6 +62,7 @@ const getOtherResponsesFromSurvey = async (cleanedFinalStates, surveyId, current
         const isLocalDevelopment = process.env.IS_OFFLINE === 'true';
 
         let Items = [];
+        let lastEvaluatedKey;
 
         if (isLocalDevelopment) {
             // Use in-memory storage for local development
@@ -80,8 +81,16 @@ const getOtherResponsesFromSurvey = async (cleanedFinalStates, surveyId, current
 
             console.log('DynamoDB query params:', JSON.stringify(params));
 
-            const result = await ddbDocClient.send(new QueryCommand(params));
-            Items = result.Items || [];
+            do {
+                const queryParams = { ...params };
+                if (lastEvaluatedKey) {
+                    queryParams.ExclusiveStartKey = lastEvaluatedKey;
+                }
+
+                const result = await ddbDocClient.send(new QueryCommand(queryParams));
+                Items = Items.concat(result.Items || []);
+                lastEvaluatedKey = result.LastEvaluatedKey;
+            } while (lastEvaluatedKey);
         }
 
         console.log('Query returned items:', Items ? Items.length : 0);
@@ -433,4 +442,9 @@ const checkForCrossDuplicateResponses = async (cleanedFinalStates, survey_id, pa
     return { duplicateResponses, responseGroups };
 }
 
-module.exports = { checkForCrossDuplicateResponses, checkIfMatch, localResponsesStorage };
+module.exports = {
+  checkForCrossDuplicateResponses,
+  checkIfMatch,
+  localResponsesStorage,
+  getOtherResponsesFromSurvey
+};


### PR DESCRIPTION
## Summary
- fetch multiple pages in getOtherResponsesFromSurvey
- export helper for testing
- add unit test verifying pages are combined

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6632b3388325b4042e89231264e9